### PR TITLE
update gem file

### DIFF
--- a/ok-hbase.gemspec
+++ b/ok-hbase.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
 
-  gem.add_dependency 'thrift', '~>0.9.0'
+  gem.add_dependency 'thrift', '~>1.0.0'
   gem.add_dependency 'activesupport'
 end


### PR DESCRIPTION
updating the thrift version removed the compilation errors without requiring any compile-time flags.
